### PR TITLE
chore: ignorar artefactos de karajan-code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules
 coverage
 package-lock.json
 output
+
+# Karajan Code artifacts
+.kj/
+.kj-ready.json
+.karajan/


### PR DESCRIPTION
## Summary
- Añade `.kj/`, `.kj-ready.json` y `.karajan/` al `.gitignore`

## Test plan
- [x] `git status` no muestra artefactos de karajan tras ejecutar `kj_audit`