### PR TITLE
fix(GLB-TSK-0004): license allow-list and execFileSync for npm view

### DIFF
--- a/generators/app/helpers.js
+++ b/generators/app/helpers.js
@@ -52,3 +52,34 @@ export function replacePackageVersion(depsMap, fetchLatestVersion) {
 
   return depsMap;
 }
+
+/**
+ * SPDX identifiers for the licenses the generator can scaffold.
+ * Any other value is rejected by `assertSupportedLicense` to avoid path
+ * traversal when building the template filename from user input.
+ */
+export const SUPPORTED_LICENSES = Object.freeze([
+  "MIT",
+  "Apache-2.0",
+  "ISC",
+  "GPL-3.0",
+]);
+
+/**
+ * Assert that a user-provided license identifier belongs to the
+ * supported allow-list. Returns the original value on success and
+ * throws a descriptive error otherwise.
+ *
+ * @param {unknown} license The value provided by the user prompt.
+ * @returns {string} The same license string, guaranteed to be safe.
+ */
+export function assertSupportedLicense(license) {
+  if (!SUPPORTED_LICENSES.includes(license)) {
+    const allowed = SUPPORTED_LICENSES.join(", ");
+    throw new Error(
+      `Unsupported license "${license}". Allowed values: ${allowed}`,
+    );
+  }
+
+  return license;
+}

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -5,11 +5,16 @@ import chalk from "chalk";
 import Generator from "yeoman-generator";
 import yosay from "yosay";
 import path from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { readFileSync, writeFileSync } from "node:fs";
 
-import { getWCClassName, replacePackageVersion } from "./helpers.js";
+import {
+  SUPPORTED_LICENSES,
+  assertSupportedLicense,
+  getWCClassName,
+  replacePackageVersion,
+} from "./helpers.js";
 
 const whoami = execSync("whoami").toString().replace(/\n/, "");
 const __filename = fileURLToPath(import.meta.url);
@@ -109,12 +114,10 @@ export default class extends Generator {
   }
 
   updateLicenseFile(directorioWC) {
+    const license = assertSupportedLicense(this.props.license);
+    const templateName = `LICENSE_${license.toUpperCase()}.md`;
     const licenseContent = readFileSync(
-      path.join(
-        __dirname,
-        "templates",
-        "LICENSE_" + this.props.license.toUpperCase() + ".md",
-      ),
+      path.join(__dirname, "templates", templateName),
       "utf8",
     );
     writeFileSync(path.join(directorioWC, "LICENSE"), licenseContent);
@@ -123,9 +126,9 @@ export default class extends Generator {
   updateDependenciesVersions() {
     const fetchLatestVersion = (depName) => {
       console.log("check version for " + depName);
-      return execSync(`npm view ${depName} version`)
-        .toString()
-        .replace(/\n/, "");
+      return execFileSync("npm", ["view", depName, "version"], {
+        encoding: "utf8",
+      }).trim();
     };
 
     replacePackageVersion(this.packageJson.dependencies, fetchLatestVersion);
@@ -146,9 +149,10 @@ export default class extends Generator {
         default: whoami,
       },
       {
-        type: "input",
+        type: "list",
         name: "license",
-        message: "LICENSE (MIT, Apache-2.0, ISC, GPL-3.0)",
+        message: "LICENSE",
+        choices: SUPPORTED_LICENSES,
         default: "Apache-2.0",
       },
       {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 
 import {
+  SUPPORTED_LICENSES,
+  assertSupportedLicense,
   getWCClassName,
   replacePackageVersion,
 } from "../generators/app/helpers.js";
@@ -87,5 +89,40 @@ describe("replacePackageVersion", () => {
         throw boom;
       }),
     ).toThrow(boom);
+  });
+});
+
+describe("assertSupportedLicense", () => {
+  it("exposes the frozen allow-list", () => {
+    expect(SUPPORTED_LICENSES).toEqual(["MIT", "Apache-2.0", "ISC", "GPL-3.0"]);
+    expect(Object.isFrozen(SUPPORTED_LICENSES)).toBe(true);
+  });
+
+  it.each(SUPPORTED_LICENSES)("accepts the supported license %s", (license) => {
+    expect(assertSupportedLicense(license)).toBe(license);
+  });
+
+  it("rejects unknown licenses", () => {
+    expect(() => assertSupportedLicense("BSD")).toThrow(/Unsupported license/);
+  });
+
+  it("rejects path traversal attempts", () => {
+    expect(() => assertSupportedLicense("../../etc/passwd")).toThrow(
+      /Unsupported license/,
+    );
+  });
+
+  it("is case sensitive against the SPDX canonical form", () => {
+    expect(() => assertSupportedLicense("mit")).toThrow(/Unsupported license/);
+    expect(() => assertSupportedLicense("APACHE-2.0")).toThrow(
+      /Unsupported license/,
+    );
+  });
+
+  it("rejects non-string input", () => {
+    expect(() => assertSupportedLicense(undefined)).toThrow(
+      /Unsupported license/,
+    );
+    expect(() => assertSupportedLicense(null)).toThrow(/Unsupported license/);
   });
 });


### PR DESCRIPTION
## Summary

Close two security-sensitive entry points flagged by \`kj_audit\`.

### Path traversal on license template lookup
- `updateLicenseFile` used `this.props.license.toUpperCase()` as a path
  segment with zero validation — malicious input such as
  `../../etc/passwd` would happily be joined into the template path.
- Introduce `assertSupportedLicense` (in `generators/app/helpers.js`)
  backed by a frozen SPDX allow-list: **MIT, Apache-2.0, ISC, GPL-3.0**.
- Switch the license prompt from `input` to `list`, closing the door
  before the value even reaches the generator.

### Command injection in \`npm view\`
- Replace
  \`execSync(\\\`npm view \${depName} version\\\`)\`
  with
  \`execFileSync("npm", ["view", depName, "version"], { encoding: "utf8" })\`.
- No shell involved, no string interpolation, and no manual
  `.toString()` / `.replace(/\n/)` afterwards.

## Tests
- 20 passing Vitest unit tests (9 new for `assertSupportedLicense`:
  happy path, unknown license, path traversal, case sensitivity,
  non-string rejection).
- `npm test` (eslint + vitest) green.

Closes GLB-TSK-0004.