### PR TITLE
chore(GLB-TSK-0005): clean up dead deps, eslint config and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Yeoman Generator to create Lit-Element WebComponent
 
 # generator-lit-element-base [![NPM version][npm-image]][npm-url]
-> Generator to create LitElement WebComponent scafolding
+> Generator to create LitElement WebComponent scaffolding
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-config-xo": "^0.43.1",
         "eslint-plugin-prettier": "^5.0.0",
-        "husky": "^8.0.3",
         "lint-staged": "^14.0.0",
         "prettier": "^3.0.2",
         "vitest": "^1.6.0",
@@ -27,7 +26,8 @@
         "yeoman-test": "^7.4.0"
       },
       "engines": {
-        "npm": ">= 4.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4823,21 +4823,6 @@
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "dependencies": {
         "ms": "^2.0.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "keywords": [
     "lit",
     "webcomponents",
-    "scafolding",
+    "scaffolding",
     "yeoman-generator"
   ],
   "devDependencies": {
@@ -25,7 +25,6 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-xo": "^0.43.1",
     "eslint-plugin-prettier": "^5.0.0",
-    "husky": "^8.0.3",
     "lint-staged": "^14.0.0",
     "prettier": "^3.0.2",
     "vitest": "^1.6.0",
@@ -33,7 +32,8 @@
     "yeoman-test": "^7.4.0"
   },
   "engines": {
-    "npm": ">= 4.0.0"
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
   },
   "dependencies": {
     "yeoman-generator": "^5.9.0",
@@ -51,13 +51,18 @@
     ]
   },
   "eslintConfig": {
+    "root": true,
     "extends": [
       "xo",
       "prettier"
     ],
+    "parserOptions": {
+      "ecmaVersion": 2022,
+      "sourceType": "module"
+    },
     "env": {
-      "jest": true,
-      "node": true
+      "node": true,
+      "es2022": true
     },
     "rules": {
       "prettier/prettier": "error"


### PR DESCRIPTION
## Summary

Housekeeping fixes flagged by the audit.

- **Drop husky**: no `.husky/` directory, no `prepare` script, no git
  hooks backing it up — it was pure dead weight in the dev dependency
  graph.
- **`engines` refresh**: replace the legacy `npm >= 4.0.0` with
  `node >= 18.0.0 / npm >= 8.0.0`. This matches what the ESM codebase
  and the `execFileSync` options already assume.
- **eslintConfig** tightened for ESLint 8 + ESM:
  - `root: true` to stop picking up ancestor `.eslintrc`.
  - `parserOptions { ecmaVersion: 2022, sourceType: "module" }`.
  - Drop the stale `jest` env (tests now run under Vitest with
    explicit imports).
  - Add `es2022`.
- **Typo**: `scafolding` → `scaffolding` in both the `keywords`
  array and the README tagline.

## Test plan
- [x] `npm install` clean.
- [x] `npm test` (pretest eslint + vitest run) green — 20/20.

Closes GLB-TSK-0005.