### PR TITLE
fix(GLB-TSK-0006): add missing LICENSE_MIT.md template

### DIFF
--- a/generators/app/templates/LICENSE_MIT.md
+++ b/generators/app/templates/LICENSE_MIT.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Add the missing `generators/app/templates/LICENSE_MIT.md`. Without this
file, selecting "MIT" at the license prompt made `updateLicenseFile`
throw `ENOENT` because it resolves the template path as
`LICENSE_${license.toUpperCase()}.md`.

## Test plan
- [x] `npm test` green (20/20 tests).
- [ ] Manual run of the generator selecting MIT to verify the template
      is copied into the scaffolded project.

Closes GLB-TSK-0006.