### PR TITLE
chore: revert package rename and bump to 1.5.6 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "generator-lit-base",
-  "version": "1.5.5",
-  "description": "Generator to create a improvment Lit WebComponent from @open-wc",
+  "name": "generator-lit-element-base",
+  "version": "1.5.6",
+  "description": "Generator to create a improvment LitElement WebComponent from @open-wc",
   "homepage": "https://github.com/manufosela/generator-litelement-webcomponent",
   "author": {
     "name": "manufosela",
@@ -14,7 +14,7 @@
   ],
   "main": "generators/app/index.js",
   "keywords": [
-    "lit",
+    "lit-element",
     "webcomponents",
     "scaffolding",
     "yeoman-generator"


### PR DESCRIPTION
## Summary

Revert the package rename introduced in PR #31 to restore continuity
with the `generator-lit-element-base` release series already published
on npm (currently `1.5.4`). Bump to `1.5.6` so the release stacks on
top of the published version without leaving gaps.

- `name`: `generator-lit-base` → `generator-lit-element-base`
- `description`: restored to the wording prior to PR #31
- `keywords`: `lit` → `lit-element`
- `version`: `1.5.5` → `1.5.6`

Every other improvement from the post-audit work (PRs #35, #36, #37,
#42, #43, #44, #45) stays in place.

## Test plan
- [x] `npm test` green (20/20).

Required before `npm publish`.